### PR TITLE
Add Docker support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 up:
-docker-compose -f infra/docker-compose.yml up -d
+	docker-compose -f infra/docker-compose.yml up -d
 
 down:
-docker-compose -f infra/docker-compose.yml down
+	docker-compose -f infra/docker-compose.yml down
 
 backend:
-cd backend && poetry run uvicorn app.main:app --reload
+	cd backend && poetry run uvicorn app.main:app --reload
 
 frontend:
-cd frontend && npm run dev
+	cd frontend && npm run dev

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,25 @@
+# backend/Dockerfile
+FROM python:3.11-slim
+
+# Install Poetry
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+    && curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python \
+    && ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry
+
+# Configure Poetry not to use virtualenvs
+ENV POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_CACHE_DIR=/tmp/poetry-cache
+
+WORKDIR /app
+
+# Install dependencies
+COPY pyproject.toml poetry.lock* ./
+RUN poetry install --no-root --no-dev
+
+# Copy application code
+COPY . .
+
+EXPOSE 8001
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# frontend/Dockerfile
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy application source
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]
+

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,15 +8,18 @@ services:
       - '5432:5432'
     volumes:
       - db_data:/var/lib/postgresql/data
+
   chroma:
     image: ghcr.io/chroma-core/chroma:latest
     ports:
       - '8000:8000'
     volumes:
-      - chroma_data:/chroma/.chroma/index
+      - chroma_data:/chroma/.chroma
+
   backend:
-    build: ../backend
-    command: poetry run uvicorn app.main:app --host 0.0.0.0 --port 8001
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/postgres
       CHROMA_HOST: http://chroma:8000
@@ -25,13 +28,16 @@ services:
       - chroma
     ports:
       - '8001:8001'
+
   frontend:
-    build: ../frontend
-    command: npm run dev
-    ports:
-      - '3000:3000'
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
     depends_on:
       - backend
+    ports:
+      - '3000:3000'
+
 volumes:
   db_data:
   chroma_data:


### PR DESCRIPTION
## Summary
- add backend and frontend Dockerfiles
- update Compose setup for all services
- standardize Makefile with tabs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*
- `npm test` in frontend *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_686cc8bf69f48320ad2665a90a8030fe