### PR TITLE
Implement search flow and tests

### DIFF
--- a/backend/app/chroma_client.py
+++ b/backend/app/chroma_client.py
@@ -2,6 +2,7 @@
 import os
 import chromadb
 from urllib.parse import urlparse
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
 
 raw = os.getenv("CHROMA_HOST", "http://chroma:8000")
 parts = urlparse(raw)
@@ -10,4 +11,15 @@ client = chromadb.HttpClient(
     host=parts.hostname or "chroma",
     port=parts.port or 8000,
     ssl=parts.scheme == "https",
+)
+
+# Default collection used across the application. It attaches an embedding
+# function so that queries can be issued with plain text.
+embedder = OpenAIEmbeddingFunction(
+    model_name="text-embedding-3-large",
+    api_key=os.getenv("OPENAI_API_KEY"),
+)
+
+collection = client.get_or_create_collection(
+    "default", embedding_function=embedder
 )

--- a/backend/tests/test_search_answer.py
+++ b/backend/tests/test_search_answer.py
@@ -1,0 +1,51 @@
+import types
+import pytest
+
+from app.routers import search as search_module, answer as answer_module
+
+class DummyEmbedResult:
+    def __init__(self):
+        self.data = [types.SimpleNamespace(embedding=[0.1, 0.2])]
+
+class DummyEmbedClient:
+    async def create(self, model, input):
+        return DummyEmbedResult()
+
+class DummyOpenAI:
+    def __init__(self):
+        self.embeddings = DummyEmbedClient()
+
+class DummyCollection:
+    def query(self, query_embeddings, n_results):
+        return {
+            "ids": [["123"]],
+            "distances": [[0.1]],
+            "metadatas": [[{"question": "dummy"}]]
+        }
+
+class DummySession:
+    async def execute(self, q):
+        class R:
+            def scalar_one_or_none(self_inner):
+                return types.SimpleNamespace(answer="ans", pdf_url="url")
+        return R()
+
+async def dummy_get_session():
+    yield DummySession()
+
+@pytest.mark.asyncio
+async def test_search_embeds_and_returns_hits(client, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(search_module, "collection", DummyCollection())
+    monkeypatch.setattr(search_module, "openai", types.SimpleNamespace(AsyncOpenAI=lambda: DummyOpenAI()))
+    resp = await client.post("/search", json={"candidates": ["foo"], "threshold": 0, "topk": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["results"][0]["q_id"] == "123"
+
+@pytest.mark.asyncio
+async def test_answer_returns_record(client, monkeypatch):
+    monkeypatch.setattr(answer_module, "get_session", dummy_get_session)
+    resp = await client.post("/answer", json={"q_id": "123"})
+    assert resp.status_code == 200
+    assert resp.json()["answer"] == "ans"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,23 +5,39 @@ import AnswerView from './components/AnswerView'
 import FeedbackButtons from './components/FeedbackButtons'
 
 const App: React.FC = () => {
-  const [candidates, setCandidates] = React.useState<string[]>([])
+  interface SearchResult {
+    q_id: string
+    question: string
+    score: number
+  }
+
+  const [results, setResults] = React.useState<SearchResult[]>([])
   const [selected, setSelected] = React.useState<string>('')
   const [answer, setAnswer] = React.useState<string>('')
   const [pdfUrl, setPdfUrl] = React.useState<string>('')
 
-  return (
-    <div className="p-4 space-y-4">
-      <QueryForm onResult={setCandidates} />
-      {candidates.length > 0 && (
-        <CandidateList candidates={candidates} onSelect={setSelected} />
-      )}
-      {selected && (
-        <AnswerView q2={selected} onLoad={(a, url) => { setAnswer(a); setPdfUrl(url) }} />
-      )}
-      {answer && <FeedbackButtons query={selected} />}
-    </div>
-  )
-}
+  const runSearch = async (candidates: string[]) => {
+    const res = await fetch('/api/search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ candidates, threshold: 0, topk: 5 })
+    })
+    const data = await res.json()
+    setResults(data.results)
+  }
+
+    return (
+      <div className="p-4 space-y-4">
+        <QueryForm onResult={runSearch} />
+        {results.length > 0 && (
+          <CandidateList results={results} onSelect={setSelected} />
+        )}
+        {selected && (
+          <AnswerView q_id={selected} onLoad={(a, url) => { setAnswer(a); setPdfUrl(url) }} />
+        )}
+        {answer && <FeedbackButtons query={selected} />}
+      </div>
+    )
+  }
 
 export default App

--- a/frontend/src/components/AnswerView.tsx
+++ b/frontend/src/components/AnswerView.tsx
@@ -1,31 +1,25 @@
 import React from 'react'
 
 interface Props {
-  q2: string
+  q_id: string
   onLoad: (answer: string, url: string) => void
 }
 
-const AnswerView: React.FC<Props> = ({ q2, onLoad }) => {
+const AnswerView: React.FC<Props> = ({ q_id, onLoad }) => {
   const [content, setContent] = React.useState('')
   React.useEffect(() => {
     const run = async () => {
-      const resSearch = await fetch('/api/search', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({candidates: [q2], threshold: 0})
-      })
-      const hit = (await resSearch.json()).results[0]
       const resAns = await fetch('/api/answer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({q_id: hit.q_id})
+        body: JSON.stringify({q_id})
       })
       const data = await resAns.json()
       setContent(data.answer)
       onLoad(data.answer, data.pdf_url)
     }
     run()
-  }, [q2])
+  }, [q_id])
 
   return (
     <div className="border p-2 whitespace-pre-wrap">

--- a/frontend/src/components/CandidateList.tsx
+++ b/frontend/src/components/CandidateList.tsx
@@ -1,22 +1,28 @@
 import React from 'react'
 // このコードは、ユーザーが選択肢から質問を選ぶためのコンポーネントです。
-interface Props {
-  candidates: string[]
-  onSelect: (q: string) => void
+interface Candidate {
+  q_id: string
+  question: string
 }
 
-const CandidateList: React.FC<Props> = ({ candidates, onSelect }) => {
-  const [other, setOther] = React.useState('')
+interface Props {
+  results: Candidate[]
+  onSelect: (q_id: string) => void
+}
 
+const CandidateList: React.FC<Props> = ({ results, onSelect }) => {
   return (
     <div className="space-y-2">
-      {candidates.map(c => (
-        <label key={c} className="block">
-          <input type="radio" name="cand" value={c} onChange={() => onSelect(c)} /> {c}
+      {results.map(r => (
+        <label key={r.q_id} className="block">
+          <input
+            type="radio"
+            name="cand"
+            value={r.q_id}
+            onChange={() => onSelect(r.q_id)}
+          /> {r.question}
         </label>
       ))}
-      <input type="radio" name="cand" value={other} onChange={() => onSelect(other)} />
-      <input value={other} onChange={e => setOther(e.target.value)} className="border" placeholder="その他" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- connect Chroma collection with embedding function
- expose top-k setting in search router
- adjust frontend to show search results and fetch answers by `q_id`
- add unit tests for search and answer endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6870615520188320b51e56e62d9051ab